### PR TITLE
Grpc pipeline with consul

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,4 +61,7 @@ updates:
     directory: "/services/pipeline-processor" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "io.grpc:grpc-netty" # breaks the build because build() is no longer exposed.  This code was ripped from the micronaut library, so just wait for them to update the grpc library
+        version: ["1.58.x"]
   

--- a/services/pipeline-processor/pom.xml
+++ b/services/pipeline-processor/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty</artifactId>
-            <version>1.59.0</version>
+            <version>1.58.0</version>
             <scope>compile</scope>
         </dependency>
 

--- a/services/pipeline-processor/src/main/java/com/krickert/search/grpc/ConsulGrpcManagedChannelFactory.java
+++ b/services/pipeline-processor/src/main/java/com/krickert/search/grpc/ConsulGrpcManagedChannelFactory.java
@@ -7,6 +7,7 @@ import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.env.Environment;
 import io.micronaut.core.type.Argument;
+import io.micronaut.grpc.channels.GrpcManagedChannelFactory;
 import io.micronaut.grpc.channels.GrpcNamedManagedChannelConfiguration;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import jakarta.annotation.PreDestroy;
@@ -25,7 +26,7 @@ import static org.apache.kafka.streams.state.RocksDBConfigSetter.LOG;
 @Singleton
 @Requires(notEnv = Environment.TEST)
 public class ConsulGrpcManagedChannelFactory implements AutoCloseable {
-
+    GrpcManagedChannelFactory factory;
     private final ApplicationContext beanContext;
     private final Map<ChannelKey, ManagedChannel> channels = new ConcurrentHashMap<>();
 

--- a/services/pipeline-processor/src/main/java/com/krickert/search/grpc/ConsulGrpcManagedChannelFactory.java
+++ b/services/pipeline-processor/src/main/java/com/krickert/search/grpc/ConsulGrpcManagedChannelFactory.java
@@ -7,7 +7,6 @@ import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.env.Environment;
 import io.micronaut.core.type.Argument;
-import io.micronaut.grpc.channels.GrpcManagedChannelFactory;
 import io.micronaut.grpc.channels.GrpcNamedManagedChannelConfiguration;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import jakarta.annotation.PreDestroy;
@@ -26,7 +25,6 @@ import static org.apache.kafka.streams.state.RocksDBConfigSetter.LOG;
 @Singleton
 @Requires(notEnv = Environment.TEST)
 public class ConsulGrpcManagedChannelFactory implements AutoCloseable {
-    GrpcManagedChannelFactory factory;
     private final ApplicationContext beanContext;
     private final Map<ChannelKey, ManagedChannel> channels = new ConcurrentHashMap<>();
 


### PR DESCRIPTION
changing dependabot to ignore the netty version since this code is ripped from the micronaut project.  When micronaut bumps to the latest version, we will take that code and use it.